### PR TITLE
Remove old contributor guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Docs.microsoft.com Github repository
 
 You've found one of the GitHub repositories that houses the source for content published to [https://docs.microsoft.com](https://docs.microsoft.com/.), home of all technical content for Microsoft's Cloud and Enterprise Division.
-
-If you are interested in making contributions to this repository, please see the [docs.microsoft.com Contributor Guide](https://github.com/Microsoft/Docs/blob/master/readme.md) for more details.  


### PR DESCRIPTION
Just removing this for now, as we've done w/other EM repos, until the revised version is complete.