### PR TITLE
Hardware inventory is randmoized by up to four hours (not two)

### DIFF
--- a/sccm/core/clients/deploy/about-client-settings.md
+++ b/sccm/core/clients/deploy/about-client-settings.md
@@ -328,7 +328,7 @@ Many of the client settings are self-explanatory. Others are described here.
 
 -   **Maximum random delay**
 
-	The collection of hardware information is randomized by up to two hours so that the operation doesn't take place simultaneously on all clients. You can set the maximum delay in order to constrain the time during which the operation takes place.      
+	The collection of hardware information is randomized by up to four hours so that the operation doesn't take place simultaneously on all clients. You can set the maximum delay in order to constrain the time during which the operation takes place.      
 
 ##  Metered Internet connections  
  You can manage how Windows 8 client computers communicate with Configuration Manager sites when they use metered Internet connections. Internet providers sometimes charge by the amount of data that you send and receive when you are on a metered Internet connection.  


### PR DESCRIPTION
Default setting in client settings is 240 minutes