### PR TITLE
Support for DA on 2008 R2 and above, clarification

### DIFF
--- a/sccm/core/plan-design/configs/support-for-windows-features-and-networks.md
+++ b/sccm/core/plan-design/configs/support-for-windows-features-and-networks.md
@@ -87,7 +87,7 @@ Configuration Manager supports the use of data deduplication with distribution p
 For more information, see [Configuration Manager Distribution Points and Windows Server 2012 Data Deduplication](http://blogs.technet.com/b/configmgrteam/archive/2014/02/18/configuration-manager-distribution-points-and-windows-server-2012-data-deduplication.aspx) on the Configuration Manager team blog, and [Data Deduplication Overview](http://technet.microsoft.com/library/hh831602.aspx) in the Windows Server TechNet library.  
 
 ##  <a name="bkmk_DA"></a> DirectAccess  
-Configuration Manager supports the DirectAccess feature in Windows Server 2008 R2 for communication between site system servers and clients.  
+Configuration Manager supports the DirectAccess feature in Windows Server 2008 R2 and above for communication between clients and site server systems.  
 
 -   When all the requirements for DirectAccess are met, DirectAccess enables Configuration Manager clients on the Internet to communicate with their assigned site as if they were on the intranet.  
 

--- a/sccm/core/plan-design/configs/support-for-windows-features-and-networks.md
+++ b/sccm/core/plan-design/configs/support-for-windows-features-and-networks.md
@@ -87,7 +87,7 @@ Configuration Manager supports the use of data deduplication with distribution p
 For more information, see [Configuration Manager Distribution Points and Windows Server 2012 Data Deduplication](http://blogs.technet.com/b/configmgrteam/archive/2014/02/18/configuration-manager-distribution-points-and-windows-server-2012-data-deduplication.aspx) on the Configuration Manager team blog, and [Data Deduplication Overview](http://technet.microsoft.com/library/hh831602.aspx) in the Windows Server TechNet library.  
 
 ##  <a name="bkmk_DA"></a> DirectAccess  
-Configuration Manager supports the DirectAccess feature in Windows Server 2008 R2 and above for communication between clients and site server systems.  
+Configuration Manager supports the DirectAccess feature in Windows Server 2008 R2 and later for communication between clients and site server systems.  
 
 -   When all the requirements for DirectAccess are met, DirectAccess enables Configuration Manager clients on the Internet to communicate with their assigned site as if they were on the intranet.  
 


### PR DESCRIPTION
Added "And above" since it is supported with 2012/2012R2/2016. Rearranged to imply clients communicating with servers instead of the other way around (all DA allows clients back in, but manage out requires ISATAP and most DA implementations don't have this).