### PR TITLE
Update support-for-sql-server-versions.md

### DIFF
--- a/sccm/core/plan-design/configs/support-for-sql-server-versions.md
+++ b/sccm/core/plan-design/configs/support-for-sql-server-versions.md
@@ -76,12 +76,18 @@ You can use this version of SQL Server with no minimum cumulative update version
 -   A primary site  
 -   A secondary site  
 
+> [!IMPORTANT]  
+>  SQL Server 2016 make use of a new Cardinality Estimator engine that could introduce some performance penalties. In order to resolve the performance , enable the legacy cardinality estimator (LEGACY_CARDINALITY_ESTIMATION = 1) per database. Refer to SQL Server 2016 documentation how to change the Cardinality Estimator.
+
 ### SQL Server 2016: Standard, Enterprise  
 You can use this version of SQL Server with no minimum cumulative update version for the following:  
 
 -   A central administration site  
 -   A primary site  
 -   A secondary site  
+
+> [!IMPORTANT]  
+>  SQL Server 2016 make use of a new Cardinality Estimator engine that could introduce some performance penalties. In order to resolve the performance , enable the legacy cardinality estimator (LEGACY_CARDINALITY_ESTIMATION = 1) per database. Refer to SQL Server 2016 documentation how to change the Cardinality Estimator.
 
 
 ### SQL Server 2014 SP2: Standard, Enterprise  


### PR DESCRIPTION
 SQL Server 2016 make use of a new Cardinality Estimator engine that introduces some performance penalties on ConfigMgr DB.
To make it simple if running the following query select * from v_DistributionPointInfo on a SQL Server 2016 instance hosting the ConfigMgr DB, the query takes several seconds to provide results even with a single DP in place.