### PR TITLE
Create about-client-settings.md

### DIFF
--- a/sccm/core/clients/deploy/about-client-settings.md
+++ b/sccm/core/clients/deploy/about-client-settings.md
@@ -243,6 +243,10 @@ Many of the client settings are self-explanatory. Others are described here.
     > -   Error codes and descriptions of **0X87D00327** and **Script is not signed** or **0X87D00320** and **The script host has not been installed yet** with the error type of **Discovery Error** in reports. An example is **Details of errors of configuration items in a configuration baseline for an asset**.  
     > -   The message **Script is not signed (Error: 87D00327; Source: CCM)** in the **DcmWmiProvider.log** file.  
 
+-   **Show notifications for new deployments**  
+
+     Choose **Yes** if you want to display a notification for deployments that have been available less than a week.  This message will display each time the client agent starts.
+
 -   **Disable deadline randomization**  
 
      This setting determines whether the client uses an activation delay of up to 2 hours to install required software updates when the deadline is reached. By default, the activation delay is disabled.  


### PR DESCRIPTION
Add detail for 'Show notifications for new deployments'

I realize this borders on self-documenting but I couldn't find anything in the existing docs that explained when these notifications appeared and for how long a deployment was considered new.  So if there's a better place for this info then by all means put it where it makes sense.  I looked for this info for some time until I eventually lucked out and came across Dune's tweet: https://twitter.com/DuneConfigured/status/803757867543105536